### PR TITLE
LrcFile: evaluation metrics

### DIFF
--- a/lrc_file/LrcSet.py
+++ b/lrc_file/LrcSet.py
@@ -93,32 +93,23 @@ class LrcSet:
 
         return self._filtered_data_files
 
-    @property
-    def metrics(self) -> dict[str, list[float]]:
+    def _metrics(self, metrics_type: str):
         ret_metrics: dict[str, list[float]] = {}
         for data_file in self.data_files:
-            for metric_name, metric in data_file.metrics.items():
+            for metric_name, metric in getattr(data_file, metrics_type).items():
                 ret_metric = ret_metrics.get(metric_name, [])
                 ret_metric.append(metric)
                 ret_metrics[metric_name] = ret_metric
         return ret_metrics
+
+    @property
+    def metrics(self) -> dict[str, list[float]]:
+        return self._metrics("metrics")
 
     @property
     def cpu_metrics(self) -> dict[str, list[float]]:
-        ret_metrics: dict[str, list[float]] = {}
-        for file in self.data_files:
-            for metric_name, metric in file.cpu_result_data.items():
-                ret_metric = ret_metrics.get(metric_name, [])
-                ret_metric.append(metric)
-                ret_metrics[metric_name] = ret_metric
-        return ret_metrics
+        return self._metrics("cpu_result_data")
 
     @property
     def flow_metrics(self) -> dict[str, list[float]]:
-        ret_metrics: dict[str, list[float]] = {}
-        for file in self.data_files:
-            for metric_name, metric in file.flow_result_data.items():
-                ret_metric = ret_metrics.get(metric_name, [])
-                ret_metric.append(metric)
-                ret_metrics[metric_name] = ret_metric
-        return ret_metrics
+        return self._metrics("flow_result_data")

--- a/lrc_file/LrcSet.py
+++ b/lrc_file/LrcSet.py
@@ -107,9 +107,21 @@ class LrcSet:
         return self._metrics("metrics")
 
     @property
+    def evaluation_metrics(self) -> dict[str, list[float]]:
+        return self._metrics("evaluation_metrics")
+
+    @property
     def cpu_metrics(self) -> dict[str, list[float]]:
         return self._metrics("cpu_result_data")
 
     @property
+    def cpu_evaluation_metrics(self) -> dict[str, list[float]]:
+        return self._metrics("cpu_evaluation_data")
+
+    @property
     def flow_metrics(self) -> dict[str, list[float]]:
         return self._metrics("flow_result_data")
+
+    @property
+    def flow_evaluation_metrics(self) -> dict[str, list[float]]:
+        return self._metrics("flow_evaluation_data")


### PR DESCRIPTION
## Description  
`{cpu,flow}_evaluation_data()` methods returns dict of metrics used during metrics evaluation. Those metrics have higher index part than `{cpu,flow}_result_data()` as it uses index of evaluation not the index of measurement evaluation. 

## Tests
`LrcFile` tests:
```python
>>> from rhextensions_lrc_file import LrcFile
>>> l = LrcFile("J:7363786_T:154173550.lrc", delete_loaded_data=False)
>>> l.flow_evaluation_data
{'189_generator_results': 9414601592.63596, '189_generator_cpu_stats': 51.60003663278907, '189_receiver_results': 9414642369.63033, '189_receiver_cpu_stats': 41.4411228303212}
>>> l.flow_result_data
{'173_generator_flow_data': 9414601592.63596, '173_generator_cpu_data': 51.60003663278907, '173_receiver_flow_data': 9414642369.63033, '173_receiver_cpu_data': 41.4411228303212}
>>> l.cpu_evaluation_data
{'182_utilization': 62.40961646774396, '183_utilization': 66.55956281838223}
>>> l.cpu_result_data
{'171_utilization': 62.40961646774396, '172_utilization': 66.55956281838223}
>>>
```
`LrcSet` tests:
```python
>>> from lrc_file import LrcSet
>>> s = LrcSet([l], "machine1")
>>> s.metrics
{'173_generator_flow_data': [9414601592.63596], '173_generator_cpu_data': [51.60003663278907], '173_receiver_flow_data': [9414642369.63033], '173_receiver_cpu_data': [41.4411228303212], '171_utilization': [62.40961646774396], '172_utilization': [66.55956281838223]}
>>> s.cpu_metrics
{'171_utilization': [62.40961646774396], '172_utilization': [66.55956281838223]}
>>> s.cpu_evaluation_metrics
{'182_utilization': [62.40961646774396], '183_utilization': [66.55956281838223]}
>>> s.flow_
s.flow_evaluation_metrics  s.flow_metrics             
>>> s.flow_metrics
{'173_generator_flow_data': [9414601592.63596], '173_generator_cpu_data': [51.60003663278907], '173_receiver_flow_data': [9414642369.63033], '173_receiver_cpu_data': [41.4411228303212]}
>>> s.flow_evaluation_metrics
{'189_generator_results': [9414601592.63596], '189_generator_cpu_stats': [51.60003663278907], '189_receiver_results': [9414642369.63033], '189_receiver_cpu_stats': [41.4411228303212]}
>>> 
```

## Review
@LNST-project/lnst-developers 