### PR TITLE
Add support for RDMA bandwidth metric

### DIFF
--- a/lrc_file/LrcSet.py
+++ b/lrc_file/LrcSet.py
@@ -133,4 +133,12 @@ class LrcSet:
     @property
     def tc_evaluation_metrics(self) -> dict[str, list[float]]:
         return self._metrics("tc_evaluation_data")
+    
+    @property
+    def rdma_metrics(self) -> dict[str, list[float]]:
+        return self._metrics("rdma_results_data")
+
+    @property
+    def rdma_evaluation_metrics(self) -> dict[str, list[float]]:
+        return self._metrics("rdma_evaluation_data")
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -148,7 +148,7 @@ virt = ["libvirt-python"]
 type = "git"
 url = "https://github.com/LNST-project/lnst.git"
 reference = "master"
-resolved_reference = "60397f6541e15fb88cb76e891dc18524abff66a3"
+resolved_reference = "3e4ad5202a973a6b19caf46f421dbebb42dd6d77"
 
 [[package]]
 name = "lxml"


### PR DESCRIPTION
This exposes the RDMA bandwidth metric. I copied the `tc` code and just changed `tc` to `rdma` and `rule_install_rate` to `bandwidth`.

Tested by setting new evaluation thresholds locally (while using these proposed changes).