### PR TITLE
poetry.lock: update lnst

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -134,9 +134,10 @@ develop = false
 ethtool = "*"
 lxml = "*"
 psutil = "^5.9.4"
-pyroute2 = "*"
+pyroute2 = "<0.9.0"
 requests = "^2.30.0"
 urllib3 = "<2"
+wheel = "^0.45.1"
 
 [package.extras]
 containers = ["podman"]
@@ -148,7 +149,7 @@ virt = ["libvirt-python"]
 type = "git"
 url = "https://github.com/LNST-project/lnst.git"
 reference = "master"
-resolved_reference = "5d430e29893e85905d8623268920cb4d5ac52dfc"
+resolved_reference = "eb30ae8697a5e94f4ace3267287d06deebba4797"
 
 [[package]]
 name = "lxml"
@@ -410,6 +411,21 @@ files = [
 brotli = ["brotli (>=1.0.9)", "brotlicffi (>=0.8.0)", "brotlipy (>=0.6.0)"]
 secure = ["certifi", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "ipaddress", "pyOpenSSL (>=0.14)", "urllib3-secure-extra"]
 socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
+
+[[package]]
+name = "wheel"
+version = "0.45.1"
+description = "A built-package format for Python"
+category = "main"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "wheel-0.45.1-py3-none-any.whl", hash = "sha256:708e7481cc80179af0e556bbf0cc00b8444c7321e2700b8d8580231d13017248"},
+    {file = "wheel-0.45.1.tar.gz", hash = "sha256:661e1abd9198507b1409a20c02106d9670b2576e916d58f520316666abca6729"},
+]
+
+[package.extras]
+test = ["pytest (>=6.0.0)", "setuptools (>=65)"]
 
 [[package]]
 name = "win-inet-pton"


### PR DESCRIPTION
Updates:
```
eb30ae86 Recipes/ENRT/BaseTunnelRecipe.py: print device namespace
6d611539 recipes/ENRT/GeneveOvsNetnsTunnelRecipe.py: config mixins to enhance performance stability
5c1f530f FlowEndpointsStatCPUMeasurementGenerator.py: use only root net namespace
e9fa26cf Controller/VirtDomainCtl.py: fix imports
ff9c1272 Recipes/ENRT: add GeneveOvsNetnsTunnelRecipe
01d13503 Recipes/ENRT/GeneveLwtTunnelRecipe.py: adjust _create_perf_flows
fc32c0dc GeneveLwtTunnelRecipe: support geneve options
25826358 Recipes/ENRT/BaseEnrtRecipe.py: add configure_and_track_ip_bulk()
e1802b3e Devices/Device.py: add ip_add_bulk()
87e6e969 lnst/Recipes/ENRT: update recipes that use PacketAssert
415e1e2b BaseTunnelRecipe: adapt to PacketAssert changes
fe528719 PacketAssert: support multiple instances
7bfa7c59 lnst: Devices: Device: Catch exceptions in _get_vf_count()
5c085a92 lnst: Common: ExecCmd: Reduce logging in exec_cmd()
f211bb82 lnst: Parameters: Trivial typo fix
769a62e9 lnst: Recipes: Introduce NftablesRuleScaleRecipe
02a28b6e lnst: Recipes: Introduce SimpleNetnsRouterRecipe
dda250f7 DevNfcRxFlowHashConfigMixin: disable symmetric hashing
a5a00b33 Recipes/ConfigMixins/DisableIdleStatesMixin.py: fix reset condition
298ecda9 TcRunMeasurementResults: rename description to describe
a58d2ff6 Recipes/ENRT/BaseEnrtRecipe.py: propagate reachable property to PingConf
ecf99d1d RecipeCommon/Ping/Recipe.py: estimate the ping duration based on interval and count
f69b7117 RecipeCommon/Ping/Recipe.py: add reachable property
ec292c79 BaremetalEnrtCommonMixins: added intel sst tf to common mixins
0b2de67d ConfigMixins: added mixin for Intel SST-TF enablement
8c16c21c DisableIdleStatesMixin: fixed deconfiguration when idlestates are not set
dd929209 docs/installation: add -c10 to ping command
7d08f82b Tests/RDMABandwidth: filter out warning message
80b81ed4 Recipes/ENRT/RecipeReqs: inherit from EnrtDeviceReqParams
3c018410 Recipes/ENRT: move common DeviceReq parameters to separate class
68dd583c Recipes/TrafficControlRecipe.py: add nic_speed and nic_model parameters
a83095e9 Recipes/BasePvPRecipe.py: add nic_speed and nic_model parameters
514b88ae Recipes/ENRT/BaseEnrtRecipe.py: add nic_speed and nic_model params
c2ed4144 Recipes/ENRT: use RecipeReqs
2c74c08c Recipes/ENRT: add RecipeReqs
2a718ce0 Recipes/SRIOVNetnsOvSRecipe.py: refactor with use of SRIOVDevices
0e0473d4 Tests/LinuxPerf: handle perf archive failure
97f991de VirtualEnrtRecipe: enable linux perf profiling
32fd3c6f LinuxPerfMeasurementGenerator: define linuxperf_hosts property
e41e8bfc docs: document new container networking approach
4ef1a038 RecipeCommon.Perf: add missing collect_simulated_results methods
4481ac48 BaseEnrtRecipe: fix generate_ping_configurations
b0236e8a functional runner use custom_lnst container networking
37190b3a .github ci-test.yml: update ubuntu version
c10695f5 container_files: add additional dependencies to Agent Dockerfile
84eaff2c deduplicate lnst setup for github ci
de6d6776 .github: add ENRT_All_Test
cd64518f Controller: move containerpoolmanager cleanup
2eb4e8cb ContainerPoolManager: add custom_lnst network backend
f2a43428 MachineMapper: container net mapping name fix
8d307c66 Recipes.ENRT: always deconfigure
a26a22bf XDPBenchMeasurement: propagate exception from receiver
750aa3e2 XDPBenchMeasurement: propagate exception from generator
251649af pyproject.toml: add pyroute2 version constraint
155c9cc6 containers: updated agent to fedora 41
69525e53 Containerized controller
9bd31f78 README: updated contributors
a6f274d8 container_files: moved agent files to separate directory
b4b315e4 pyproject.toml: add includes into wheel
aa190bf0 AggregatedXDPBenchMeasurementResults: add individual_results
1f09e4e8 XDPBenchMeasurement: rename loop variable
85da5919 StatCPUMeasurementResults: fix __init__ arguments
38d91b15 Perf.Measurements: report measurement_success in MeasurementResult
d3e54bb1 Perf.Measurements.TcRunMeasurement: remove run_success
198bdb45 Perf.Measurements: add measurement_success property
a5ee3138 Recipes: added XDP tx recipe
f4e828ea XDPBench: exported xdp-bench tool arguments
55b69005 XDPBenchOutputParser: added support for xdp tx mode
d6c10465 XDPBenchMeasurement: fixed json formatter
92fa5829 XDPBenchResults: split inheritance tree
212cc2eb Recipes/ENRT/BaseLACPRecipe.py: adapt to BondingMixin changes
b9c990bc docs/specific_scenarios.rst: add ipsec_esp_aead_recipe
6432a6b0 docs: add use_vfs_mixin.rst
f11b0c4b docs: add bonding_mixin.rst
fc2288f7 Recipes/ENRT/DoubleBondRecipe: add vf_trust_dev_list property
524bf4b1 Recipes/ENRT/VlansOverBondRecipe: add vf_trust_dev_list property
266c59b6 Recipes/ENRT/BondRecipe: add vf_trust_dev_list property
9f48c73c Recipes/ENRT/UseVfsMixin.py: add vf_trust parameter
e89d027b Devices/Device.py: add vf_trust method
c783f039 Recipes/ENRT/VlansOverBondRecipe.py: use BondingMixin
aca678b1 Recipes/ENRT/DoubleBondRecipe.py: use BondingMixin
64b72d34 Recipes/ENRT/BondRecipe.py: use BondingMixin
0ec2c5fc Recipes/ENRT: add BondingMixin
a42be24d Perf.Measurements.Results: fix warmup/warmdown calculation
7d06e187 Perf.Measurements: set minimal PerfInterval duration to 1
44828270 IperfFlowMeasurement: fix iperf result structure for no connection
13b0d7fc PktGen: removed unnecessary f-strings
82c5d30e PktGen: fixed IPv6 support
de798725 .github/runner.py: use cni backend
3c4c7492 ContainerPoolManager: add netavark support
6e394f95 Tests/PktGen: load pktgen module
f5812314 Recipes/ENRT: call test_wide_configuration before creating devices
d6104cb5 Recipes/ENRT/UseVfsMixin: add generate_test_wide_description
d2ba6080 Recipes/ENRT/BaremetalEnrtRecipe.py: inherit UseVfsMixin
494b89b0 Recipes/ENRT: add UseVfsMixin
029f76ff Recipes/ENRT/SRIOVDevices.py: fix for unavailable vf_reps
7119299c Recipes/ENRT/SRIOVDevices.py: fix variable typo
824a3eb6 Recipes/ENRT: split SRIOVDevices to standalone module
38f042c7 LongLivedConnections: add setsockopt IP_BIND_ADDRESS_NO_PORT
b073cada Recipes: Full conntrack table insertion rate recipe
ae639e46 Device: added {keep,remove}_on_down functions
6dbec4bf Tests: Long lived connections module
b3bdb188 Agent/Conditions: Waiting for connections establishment
a51d4de3 Agent: waiting for condition on agent side
37b7b06c BaseTestModule class hierarchy split
0621fc1c Recipes: added Conntrack insertion rate recipe
fb92de78 FirewallMixin: fixed pickling for dynamic derived classes
c5cb780a IpAddress: ip_version_string function moved to IpAddress
cf77e389 BaseRESTConfigMixin: retrying of API call
dd90b17c lnst.Tests.PktGen: increase runtime_estimate by 3 seconds to hopefully resolve a race condition
e1b15d18 fix strings with escape sequences
7c0cc6f7 pyproject.toml: add pylint dev dependency
35ada724 Tests/Ping: save stdout/stderr to _res_data
7ea41a22 Tests/Ping: log stdout
32464844 Controller/Machine.py: handle exceptions when accessing peer_name attribute
87c23fbe Agent/InterfaceManager: clear _nl_link_update when remapping a device
34d9766e Controller/Machine.py: pass the peer name when moving device to netns
```